### PR TITLE
Document network architecture

### DIFF
--- a/core/network.md
+++ b/core/network.md
@@ -1,0 +1,35 @@
+# Core Network Architecture
+
+Each BVC exists as an independent Tendermint network, and the DC is a separate,
+independent Tendermint network. Each node of a given network should exist on a
+separate instance (as in a VM or docker container). The nodes of a given
+Tendermint network must be able to communicate with each other via Tendermint's
+peer-to-peer layer. Additionally, each node provides an RPC interface
+which clients use to submit transactions and query the state of the chain.
+
+```mermaind
+flowchart TD
+    subgraph BVC0
+    direction LR
+    B0N0[N0] --- B0N1
+    B0N1[N1] --- B0N2
+    B0N2[N2] --- B0N0
+    end
+
+    subgraph DC
+    direction LR
+    DN0[N0] --- DN1
+    DN1[N1] --- DN2
+    DN2[N2] --- DN0
+    end
+
+    subgraph BVC1
+    direction LR
+    B1N0[N0] --- B1N1
+    B1N1[N1] --- B1N2
+    B1N2[N2] --- B1N0
+    end
+
+    BVC0 --> DC
+    BVC1 --> DC
+```

--- a/core/network.md
+++ b/core/network.md
@@ -7,7 +7,7 @@ Tendermint network must be able to communicate with each other via Tendermint's
 peer-to-peer layer. Additionally, each node provides an RPC interface
 which clients use to submit transactions and query the state of the chain.
 
-```mermaind
+```mermaid
 flowchart TD
     subgraph BVC0
     direction LR


### PR DESCRIPTION
Is this description correct? Is there anything I should add?

I am trying to clearly establish the relationship between the protocol and the infrastructure. I am distinguishing between the 'core network', by which I mean the part of the network that must exist, without which Accumulate would not function; vs the not-core/peripheral network, by which I mean nodes created by 3rd parties, without which Accumulate would continue to function.

For those who want to:
- Set up their own nodes,
- Make open source contributions to the project,
- Work for DeFi Devs as developers (i.e. onboarding),

The purpose of this document is to help them understand how Accumulate infrastructure works.

Here's the rendered version: https://gitlab.com/accumulatenetwork/architecture/-/blob/AC-297-document-network-architecture/core/network.md